### PR TITLE
Add static message management page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -46,6 +46,17 @@ export const routes: Routes = [
     canActivate: [authGuard],
     loadComponent: () => import('./features/ticket-panel/ticket-panel-edit.component').then(m => m.TicketPanelEditComponent)
   },
+
+  {
+    path: 'server/:serverId/static-messages',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/static-message-list.component').then(m => m.StaticMessageListComponent)
+  },
+  {
+    path: 'server/:serverId/static-message/:staticMessageId',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/static-message-edit.component').then(m => m.StaticMessageEditComponent)
+  },
   {
     path: 'server/:serverId/cnt-requests',
     canActivate: [authGuard],

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -12,6 +12,27 @@ export class AuthService {
   private router = inject(Router);
   private readonly debugOAuth = !environment.production;
 
+  private getBrowserOrigin(): string | null {
+    if (typeof window === 'undefined' || !window.location?.origin) {
+      return null;
+    }
+
+    return window.location.origin;
+  }
+
+  private resolveRedirectUri(configuredRedirectUri: string): string {
+    const browserOrigin = this.getBrowserOrigin();
+    if (!browserOrigin) {
+      return configuredRedirectUri;
+    }
+
+    return `${browserOrigin}/auth/callback`;
+  }
+
+  private resolvePostLogoutRedirectUri(configuredPostLogoutRedirectUri: string): string {
+    return this.getBrowserOrigin() || configuredPostLogoutRedirectUri;
+  }
+
   private isAuthenticatedSubject = new BehaviorSubject<boolean>(false);
   public isAuthenticated$ = this.isAuthenticatedSubject.asObservable();
 
@@ -37,12 +58,12 @@ export class AuthService {
   async initialize(): Promise<void> {
     this.oauthService.configure({
       issuer: environment.keycloak.issuer,
-      redirectUri: environment.keycloak.redirectUri,
+      redirectUri: this.resolveRedirectUri(environment.keycloak.redirectUri),
       clientId: environment.keycloak.clientId,
       responseType: 'code',
       scope: environment.keycloak.scope,
       showDebugInformation: this.debugOAuth,
-      postLogoutRedirectUri: environment.keycloak.postLogoutRedirectUri
+      postLogoutRedirectUri: this.resolvePostLogoutRedirectUri(environment.keycloak.postLogoutRedirectUri)
     });
 
     this.oauthService.setStorage(sessionStorage);

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -11,6 +11,7 @@ export class AuthService {
   private oauthService = inject(OAuthService);
   private router = inject(Router);
   private readonly debugOAuth = !environment.production;
+  private initialized = false;
 
   private getBrowserOrigin(): string | null {
     if (typeof window === 'undefined' || !window.location?.origin) {
@@ -71,25 +72,51 @@ export class AuthService {
 
     try {
       await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+      await this.refreshAuthenticatedState();
 
-      if (this.oauthService.hasValidAccessToken()) {
-        // Load user profile from userinfo endpoint
-        await this.oauthService.loadUserProfile();
-        this.isAuthenticatedSubject.next(true);
-
-        if (this.debugOAuth) {
-          console.log('[OAuth] Initialized successfully');
-        }
+      if (this.debugOAuth && this.oauthService.hasValidAccessToken()) {
+        console.log('[OAuth] Initialized successfully');
       }
     } catch (err) {
       if (this.debugOAuth) {
         console.error('[OAuth] Initialization failed:', err);
       }
+    } finally {
+      this.initialized = true;
     }
   }
 
+  async completeLogin(): Promise<boolean> {
+    if (!this.initialized) {
+      await this.initialize();
+    } else if (!this.oauthService.hasValidAccessToken()) {
+      await this.oauthService.tryLoginCodeFlow();
+    }
+
+    return this.refreshAuthenticatedState();
+  }
+
+  private async refreshAuthenticatedState(): Promise<boolean> {
+    const hasValidToken = this.oauthService.hasValidAccessToken();
+    this.isAuthenticatedSubject.next(hasValidToken);
+
+    if (!hasValidToken) {
+      return false;
+    }
+
+    try {
+      await this.oauthService.loadUserProfile();
+    } catch (err) {
+      if (this.debugOAuth) {
+        console.warn('[OAuth] Failed to load user profile after login:', err);
+      }
+    }
+
+    return true;
+  }
+
   login(returnUrl?: string) {
-    if (returnUrl) {
+    if (returnUrl && returnUrl !== '/login' && !returnUrl.startsWith('/auth/callback')) {
       sessionStorage.setItem('auth_return_url', returnUrl);
     }
     this.oauthService.initCodeFlow();
@@ -116,6 +143,6 @@ export class AuthService {
   handleAuthCallback() {
     const returnUrl = sessionStorage.getItem('auth_return_url') || '/dashboard';
     sessionStorage.removeItem('auth_return_url');
-    this.router.navigate([returnUrl]);
+    this.router.navigateByUrl(returnUrl);
   }
 }

--- a/src/app/features/auth/auth-callback.component.ts
+++ b/src/app/features/auth/auth-callback.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 @Component({
   selector: 'app-auth-callback',
@@ -16,13 +16,20 @@ import { OAuthService } from 'angular-oauth2-oidc';
 })
 export class AuthCallbackComponent implements OnInit {
   private authService = inject(AuthService);
-  private oauthService = inject(OAuthService);
+  private router = inject(Router);
 
   async ngOnInit() {
-    // Load user profile from userinfo endpoint after callback
-    if (this.oauthService.hasValidAccessToken()) {
-      await this.oauthService.loadUserProfile();
+    try {
+      const completedLogin = await this.authService.completeLogin();
+
+      if (completedLogin) {
+        this.authService.handleAuthCallback();
+      } else {
+        this.router.navigate(['/login']);
+      }
+    } catch (err) {
+      console.error('[OAuth] Failed to complete authentication callback:', err);
+      this.router.navigate(['/login']);
     }
-    this.authService.handleAuthCallback();
   }
 }

--- a/src/app/features/server/server-detail.component.ts
+++ b/src/app/features/server/server-detail.component.ts
@@ -167,6 +167,25 @@ import {
         }
       </div>
 
+
+      <!-- Static Messages Section -->
+      <div class="card mb-8">
+        <div class="flex justify-between items-center mb-6">
+          <h3 class="text-2xl font-semibold">Static Messages</h3>
+        </div>
+
+        <p class="text-gray-400 mb-4">
+          Edit static message channels, embed overrides, and active state.
+        </p>
+
+        <a
+          [routerLink]="['/server', serverId, 'static-messages']"
+          class="btn btn-primary"
+        >
+          Manage Static Messages
+        </a>
+      </div>
+
       <!-- CNT Requests Section -->
       <div class="card">
         <div class="flex justify-between items-center mb-6">

--- a/src/app/features/static-message-edit.component.ts
+++ b/src/app/features/static-message-edit.component.ts
@@ -1,0 +1,236 @@
+import {ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
+import {ActivatedRoute, RouterLink} from '@angular/router';
+import {
+  DiscordChannelControllerService,
+  DiscordChannelModel,
+  StaticMessageControllerService,
+  StaticMessageModel,
+  StaticMessageUpdateModel
+} from '@dungeon-hub/api-client';
+import {AutocompleteComponent} from '../shared/components/autocomplete/autocomplete.component';
+
+type StaticMessageWithActive = StaticMessageModel & { active?: boolean };
+type StaticMessageUpdateWithActive = StaticMessageUpdateModel & { active?: boolean };
+
+@Component({
+  selector: 'app-static-message-edit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, AutocompleteComponent],
+  template: `
+    <div class="container mx-auto px-4 py-8 max-w-5xl">
+      <div class="mb-8">
+        <a [routerLink]="['/server', serverId, 'static-messages']" class="btn btn-secondary mb-4 inline-block">
+          ← Back to Static Messages
+        </a>
+        <h2 class="text-3xl font-bold holographic">Edit Static Message #{{ staticMessageId }}</h2>
+      </div>
+
+      @if (loadError) {
+        <div class="card bg-red-900/20 border-red-500 mb-8">
+          <p class="text-red-400">{{ loadError }}</p>
+        </div>
+      }
+
+      @if (saveSuccess) {
+        <div class="card bg-green-900/20 border-green-500 mb-8">
+          <p class="text-green-400">Static message saved successfully.</p>
+        </div>
+      }
+
+      @if (loading) {
+        <div class="card text-center py-12">
+          <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+          <p class="mt-4 text-gray-400">Loading...</p>
+        </div>
+      }
+
+      @if (!loading && form) {
+        <form [formGroup]="form" (ngSubmit)="save()" class="space-y-6">
+          <div class="card">
+            <h3 class="text-xl font-semibold mb-4">Static Message Settings</h3>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label class="label">Type</label>
+                <input [value]="message?.staticMessageType" class="input" disabled />
+              </div>
+              <div>
+                <label class="label">Message ID</label>
+                <input formControlName="messageId" type="text" class="input" />
+              </div>
+              <div class="md:col-span-2">
+                <label class="label">Channel</label>
+                <app-autocomplete
+                  [items]="discordChannels"
+                  displayKey="name"
+                  valueKey="id"
+                  placeholder="Search channels..."
+                  [selectedItem]="selectedChannel"
+                  (selectedItemChange)="onChannelSelected($event)"
+                  nullLabel="Select a channel"
+                  groupByKey="category.id"
+                  groupDisplayKey="category.name"
+                ></app-autocomplete>
+                @if (!selectedChannel && form.get('channelId')?.touched) {
+                  <small class="text-red-400">Channel is required</small>
+                }
+              </div>
+              <div class="md:col-span-2">
+                <label class="label">Channel ID</label>
+                <input formControlName="channelId" type="text" class="input" />
+                <small class="text-gray-400">The API client exposes this as <code>channelId</code>.</small>
+              </div>
+              <div class="flex items-center">
+                <label class="flex items-center cursor-pointer">
+                  <input formControlName="active" type="checkbox" class="mr-2" />
+                  <span class="text-gray-300">Active</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3 class="text-xl font-semibold mb-4">Embed Override</h3>
+            <textarea formControlName="embedOverride" rows="12" class="input font-mono text-sm"></textarea>
+            <div class="mt-3 flex items-center">
+              <label class="flex items-center cursor-pointer">
+                <input formControlName="resetEmbedOverride" type="checkbox" class="mr-2" />
+                <span class="text-gray-300">Reset embed override</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3 class="text-xl font-semibold mb-4">Object IDs</h3>
+            <textarea formControlName="objectIds" rows="4" class="input font-mono text-sm"></textarea>
+            <small class="text-gray-400">One object ID per line.</small>
+          </div>
+
+          <div class="flex gap-4">
+            <button type="submit" class="btn btn-primary" [disabled]="saving || form.invalid">
+              {{ saving ? 'Saving...' : 'Save Changes' }}
+            </button>
+            <a [routerLink]="['/server', serverId, 'static-messages']" class="btn btn-secondary">Cancel</a>
+          </div>
+
+          @if (saveError) {
+            <p class="text-red-400">{{ saveError }}</p>
+          }
+        </form>
+      }
+    </div>
+  `
+})
+export class StaticMessageEditComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private fb = inject(FormBuilder);
+  private staticMessageService = inject(StaticMessageControllerService);
+  private discordChannelService = inject(DiscordChannelControllerService);
+  private cdr = inject(ChangeDetectorRef);
+
+  serverId!: string;
+  staticMessageId!: string;
+  message: StaticMessageWithActive | null = null;
+  discordChannels: DiscordChannelModel[] = [];
+  selectedChannel: DiscordChannelModel | null = null;
+  loading = true;
+  saving = false;
+  loadError: string | null = null;
+  saveError: string | null = null;
+  saveSuccess = false;
+
+  form = this.fb.group({
+    channelId: ['', Validators.required],
+    messageId: [''],
+    active: [true],
+    embedOverride: [''],
+    resetEmbedOverride: [false],
+    objectIds: ['']
+  });
+
+  ngOnInit(): void {
+    this.serverId = this.route.snapshot.params['serverId'];
+    this.staticMessageId = this.route.snapshot.params['staticMessageId'];
+    this.form.get('channelId')?.valueChanges.subscribe(channelId => {
+      this.selectedChannel = this.discordChannels.find(channel => channel.id === channelId) || null;
+    });
+    this.loadChannels();
+    this.loadMessage();
+  }
+
+  loadChannels(): void {
+    this.discordChannelService.getAllChannels(this.serverId, false).subscribe({
+      next: channels => {
+        this.discordChannels = channels || [];
+        this.selectedChannel = this.discordChannels.find(channel => channel.id === this.form.value.channelId) || null;
+        this.cdr.detectChanges();
+      },
+      error: err => console.error('Failed to load Discord channels:', err)
+    });
+  }
+
+  loadMessage(): void {
+    this.loading = true;
+    this.loadError = null;
+    this.staticMessageService.getById2(this.serverId, this.staticMessageId).subscribe({
+      next: message => {
+        this.message = message;
+        this.form.patchValue({
+          channelId: message.channelId,
+          messageId: message.messageId || '',
+          active: (message as StaticMessageWithActive).active ?? true,
+          embedOverride: message.embedOverride || '',
+          resetEmbedOverride: false,
+          objectIds: (message.objectIds || []).join('\n')
+        });
+        this.selectedChannel = this.discordChannels.find(channel => channel.id === message.channelId) || null;
+        this.loading = false;
+        this.cdr.detectChanges();
+      },
+      error: err => {
+        this.loadError = 'Failed to load static message. Please try again.';
+        console.error('Error loading static message:', err);
+        this.loading = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  onChannelSelected(channel: DiscordChannelModel | null): void {
+    this.selectedChannel = channel;
+    this.form.patchValue({channelId: channel?.id || ''});
+  }
+
+  save(): void {
+    if (this.form.invalid || this.saving) return;
+    this.saving = true;
+    this.saveError = null;
+    this.saveSuccess = false;
+
+    const value = this.form.value;
+    const updateModel: StaticMessageUpdateWithActive = {
+      channelId: this.selectedChannel?.id || value.channelId || undefined,
+      messageId: value.messageId || undefined,
+      active: value.active ?? true,
+      embedOverride: value.embedOverride || undefined,
+      resetEmbedOverride: value.resetEmbedOverride ?? false,
+      objectIds: (value.objectIds || '').split('\n').map(id => id.trim()).filter(Boolean)
+    };
+
+    this.staticMessageService.updateStaticMessage(this.serverId, this.staticMessageId, updateModel).subscribe({
+      next: message => {
+        this.message = message;
+        this.saving = false;
+        this.saveSuccess = true;
+        this.cdr.detectChanges();
+      },
+      error: err => {
+        this.saveError = 'Failed to save static message. Please try again.';
+        console.error('Error saving static message:', err);
+        this.saving = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+}

--- a/src/app/features/static-message-edit.component.ts
+++ b/src/app/features/static-message-edit.component.ts
@@ -83,6 +83,9 @@ function jsonValidator(control: AbstractControl): ValidationErrors | null {
               <div>
                 <label class="label">Message ID</label>
                 <p class="px-3 py-2 bg-gray-800 rounded text-gray-200 break-all">{{ message?.messageId || 'Not sent yet' }}</p>
+                @if (message?.messageId) {
+                  <a [href]="getDiscordMessageUrl()" target="_blank" rel="noopener noreferrer" class="btn btn-secondary mt-3 inline-block">Jump to Message</a>
+                }
               </div>
               <div class="md:col-span-2">
                 <label class="label">Channel</label>
@@ -255,6 +258,10 @@ export class StaticMessageEditComponent implements OnInit {
     this.objectOptions = options;
     this.selectedObjectOptions = options.filter(option => selectedIds.includes(option.id));
     this.cdr.detectChanges();
+  }
+
+  getDiscordMessageUrl(): string {
+    return `https://discord.com/channels/${this.serverId}/${this.message?.channelId}/${this.message?.messageId}`;
   }
 
   onChannelSelected(channel: DiscordChannelModel | null): void {

--- a/src/app/features/static-message-edit.component.ts
+++ b/src/app/features/static-message-edit.component.ts
@@ -18,6 +18,7 @@ import {MultiSelectAutocompleteComponent} from '../shared/components/multi-selec
 import {getStaticMessageTypeLabel, StaticMessageType} from './static-message/static-message-labels';
 import {
   StaticMessageObjectOption,
+  getObjectOptionTypeLabel,
   supportsObjectIds,
   toCarryTierOption,
   toCarryTypeOption,
@@ -124,7 +125,7 @@ function jsonValidator(control: AbstractControl): ValidationErrors | null {
 
           @if (message && shouldShowObjectIds(message.staticMessageType)) {
             <div class="card">
-              <h3 class="text-xl font-semibold mb-4">Object IDs</h3>
+              <h3 class="text-xl font-semibold mb-4">{{ getObjectOptionLabel(message.staticMessageType) }}</h3>
               <app-multi-select-autocomplete
                 [items]="objectOptions"
                 [selectedItems]="selectedObjectOptions"
@@ -197,6 +198,10 @@ export class StaticMessageEditComponent implements OnInit {
 
   shouldShowObjectIds(type: StaticMessageType): boolean {
     return supportsObjectIds(type);
+  }
+
+  getObjectOptionLabel(type: StaticMessageType): string {
+    return getObjectOptionTypeLabel(type) || 'Object';
   }
 
   loadChannels(): void {

--- a/src/app/features/static-message-edit.component.ts
+++ b/src/app/features/static-message-edit.component.ts
@@ -1,23 +1,48 @@
 import {ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
+import {forkJoin, of} from 'rxjs';
 import {CommonModule} from '@angular/common';
-import {FormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
+import {AbstractControl, FormBuilder, ReactiveFormsModule, ValidationErrors, Validators} from '@angular/forms';
 import {ActivatedRoute, RouterLink} from '@angular/router';
 import {
+  CarryTierControllerService,
+  CarryTypeControllerService,
   DiscordChannelControllerService,
   DiscordChannelModel,
   StaticMessageControllerService,
   StaticMessageModel,
-  StaticMessageUpdateModel
+  StaticMessageUpdateModel,
+  TicketPanelControllerService
 } from '@dungeon-hub/api-client';
 import {AutocompleteComponent} from '../shared/components/autocomplete/autocomplete.component';
+import {MultiSelectAutocompleteComponent} from '../shared/components/multi-select-autocomplete/multi-select-autocomplete.component';
+import {getStaticMessageTypeLabel, StaticMessageType} from './static-message/static-message-labels';
+import {
+  StaticMessageObjectOption,
+  supportsObjectIds,
+  toCarryTierOption,
+  toCarryTypeOption,
+  toTicketPanelOption
+} from './static-message/static-message-object-options';
 
 type StaticMessageWithActive = StaticMessageModel & { active?: boolean };
 type StaticMessageUpdateWithActive = StaticMessageUpdateModel & { active?: boolean };
 
+function jsonValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (!value || !value.trim()) return null;
+
+  try {
+    JSON.parse(value);
+    return null;
+  } catch {
+    return {invalidJson: true};
+  }
+}
+
 @Component({
   selector: 'app-static-message-edit',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, AutocompleteComponent],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, AutocompleteComponent, MultiSelectAutocompleteComponent],
   template: `
     <div class="container mx-auto px-4 py-8 max-w-5xl">
       <div class="mb-8">
@@ -53,11 +78,11 @@ type StaticMessageUpdateWithActive = StaticMessageUpdateModel & { active?: boole
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label class="label">Type</label>
-                <input [value]="message?.staticMessageType" class="input" disabled />
+                <p class="px-3 py-2 bg-gray-800 rounded text-gray-200">{{ message ? getTypeLabel(message.staticMessageType) : 'Unknown' }}</p>
               </div>
               <div>
                 <label class="label">Message ID</label>
-                <input formControlName="messageId" type="text" class="input" />
+                <p class="px-3 py-2 bg-gray-800 rounded text-gray-200 break-all">{{ message?.messageId || 'Not sent yet' }}</p>
               </div>
               <div class="md:col-span-2">
                 <label class="label">Channel</label>
@@ -76,11 +101,6 @@ type StaticMessageUpdateWithActive = StaticMessageUpdateModel & { active?: boole
                   <small class="text-red-400">Channel is required</small>
                 }
               </div>
-              <div class="md:col-span-2">
-                <label class="label">Channel ID</label>
-                <input formControlName="channelId" type="text" class="input" />
-                <small class="text-gray-400">The API client exposes this as <code>channelId</code>.</small>
-              </div>
               <div class="flex items-center">
                 <label class="flex items-center cursor-pointer">
                   <input formControlName="active" type="checkbox" class="mr-2" />
@@ -93,19 +113,26 @@ type StaticMessageUpdateWithActive = StaticMessageUpdateModel & { active?: boole
           <div class="card">
             <h3 class="text-xl font-semibold mb-4">Embed Override</h3>
             <textarea formControlName="embedOverride" rows="12" class="input font-mono text-sm"></textarea>
-            <div class="mt-3 flex items-center">
-              <label class="flex items-center cursor-pointer">
-                <input formControlName="resetEmbedOverride" type="checkbox" class="mr-2" />
-                <span class="text-gray-300">Reset embed override</span>
-              </label>
-            </div>
+            @if (form.get('embedOverride')?.hasError('invalidJson') && form.get('embedOverride')?.touched) {
+              <small class="text-red-400">Invalid JSON format</small>
+            }
+            <small class="text-gray-400 block mt-2">Leave empty to reset the embed override.</small>
           </div>
 
-          <div class="card">
-            <h3 class="text-xl font-semibold mb-4">Object IDs</h3>
-            <textarea formControlName="objectIds" rows="4" class="input font-mono text-sm"></textarea>
-            <small class="text-gray-400">One object ID per line.</small>
-          </div>
+          @if (message && shouldShowObjectIds(message.staticMessageType)) {
+            <div class="card">
+              <h3 class="text-xl font-semibold mb-4">Object IDs</h3>
+              <app-multi-select-autocomplete
+                [items]="objectOptions"
+                [selectedItems]="selectedObjectOptions"
+                (selectedItemsChange)="onObjectOptionsSelected($event)"
+                displayKey="name"
+                valueKey="id"
+                placeholder="Search objects..."
+                nullLabel="No objects selected"
+              ></app-multi-select-autocomplete>
+            </div>
+          }
 
           <div class="flex gap-4">
             <button type="submit" class="btn btn-primary" [disabled]="saving || form.invalid">
@@ -127,13 +154,18 @@ export class StaticMessageEditComponent implements OnInit {
   private fb = inject(FormBuilder);
   private staticMessageService = inject(StaticMessageControllerService);
   private discordChannelService = inject(DiscordChannelControllerService);
+  private ticketPanelService = inject(TicketPanelControllerService);
+  private carryTypeService = inject(CarryTypeControllerService);
+  private carryTierService = inject(CarryTierControllerService);
   private cdr = inject(ChangeDetectorRef);
 
   serverId!: string;
   staticMessageId!: string;
   message: StaticMessageWithActive | null = null;
   discordChannels: DiscordChannelModel[] = [];
+  objectOptions: StaticMessageObjectOption[] = [];
   selectedChannel: DiscordChannelModel | null = null;
+  selectedObjectOptions: StaticMessageObjectOption[] = [];
   loading = true;
   saving = false;
   loadError: string | null = null;
@@ -142,11 +174,8 @@ export class StaticMessageEditComponent implements OnInit {
 
   form = this.fb.group({
     channelId: ['', Validators.required],
-    messageId: [''],
     active: [true],
-    embedOverride: [''],
-    resetEmbedOverride: [false],
-    objectIds: ['']
+    embedOverride: ['', jsonValidator]
   });
 
   ngOnInit(): void {
@@ -157,6 +186,14 @@ export class StaticMessageEditComponent implements OnInit {
     });
     this.loadChannels();
     this.loadMessage();
+  }
+
+  getTypeLabel(type: StaticMessageType): string {
+    return getStaticMessageTypeLabel(type);
+  }
+
+  shouldShowObjectIds(type: StaticMessageType): boolean {
+    return supportsObjectIds(type);
   }
 
   loadChannels(): void {
@@ -178,13 +215,11 @@ export class StaticMessageEditComponent implements OnInit {
         this.message = message;
         this.form.patchValue({
           channelId: message.channelId,
-          messageId: message.messageId || '',
           active: (message as StaticMessageWithActive).active ?? true,
-          embedOverride: message.embedOverride || '',
-          resetEmbedOverride: false,
-          objectIds: (message.objectIds || []).join('\n')
+          embedOverride: message.embedOverride || ''
         });
         this.selectedChannel = this.discordChannels.find(channel => channel.id === message.channelId) || null;
+        this.loadObjectOptions(message.staticMessageType, message.objectIds || []);
         this.loading = false;
         this.cdr.detectChanges();
       },
@@ -197,25 +232,54 @@ export class StaticMessageEditComponent implements OnInit {
     });
   }
 
+  loadObjectOptions(type: StaticMessageType, selectedIds: string[] = []): void {
+    this.objectOptions = [];
+    this.selectedObjectOptions = [];
+    if (type === 'TicketPanel') {
+      this.ticketPanelService.getAllTicketPanels(this.serverId).subscribe({next: panels => this.setObjectOptions((panels || []).map(toTicketPanelOption), selectedIds)});
+    } else if (type === 'ScoreLeaderboard') {
+      this.carryTypeService.getAllCarryTypes(this.serverId).subscribe({next: carryTypes => this.setObjectOptions((carryTypes || []).map(toCarryTypeOption), selectedIds)});
+    } else if (type === 'PriceMessage') {
+      this.carryTypeService.getAllCarryTypes(this.serverId).subscribe({
+        next: carryTypes => {
+          const tierRequests = (carryTypes || []).map(carryType => this.carryTierService.getAllCarryTiers(this.serverId, carryType.id));
+          (tierRequests.length ? forkJoin(tierRequests) : of([])).subscribe({
+            next: carryTierGroups => this.setObjectOptions(carryTierGroups.flat().map(toCarryTierOption), selectedIds)
+          });
+        }
+      });
+    }
+  }
+
+  setObjectOptions(options: StaticMessageObjectOption[], selectedIds: string[]): void {
+    this.objectOptions = options;
+    this.selectedObjectOptions = options.filter(option => selectedIds.includes(option.id));
+    this.cdr.detectChanges();
+  }
+
   onChannelSelected(channel: DiscordChannelModel | null): void {
     this.selectedChannel = channel;
     this.form.patchValue({channelId: channel?.id || ''});
   }
 
+  onObjectOptionsSelected(options: StaticMessageObjectOption[]): void {
+    this.selectedObjectOptions = options;
+  }
+
   save(): void {
-    if (this.form.invalid || this.saving) return;
+    if (this.form.invalid || this.saving || !this.message) return;
     this.saving = true;
     this.saveError = null;
     this.saveSuccess = false;
 
     const value = this.form.value;
+    const embedOverride = (value.embedOverride || '').trim();
     const updateModel: StaticMessageUpdateWithActive = {
       channelId: this.selectedChannel?.id || value.channelId || undefined,
-      messageId: value.messageId || undefined,
       active: value.active ?? true,
-      embedOverride: value.embedOverride || undefined,
-      resetEmbedOverride: value.resetEmbedOverride ?? false,
-      objectIds: (value.objectIds || '').split('\n').map(id => id.trim()).filter(Boolean)
+      embedOverride: embedOverride || undefined,
+      resetEmbedOverride: !embedOverride,
+      objectIds: supportsObjectIds(this.message.staticMessageType) ? this.selectedObjectOptions.map(option => option.id) : []
     };
 
     this.staticMessageService.updateStaticMessage(this.serverId, this.staticMessageId, updateModel).subscribe({

--- a/src/app/features/static-message-list.component.ts
+++ b/src/app/features/static-message-list.component.ts
@@ -1,0 +1,232 @@
+import {ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {ActivatedRoute, RouterLink} from '@angular/router';
+import {
+  DiscordChannelControllerService,
+  DiscordChannelModel,
+  StaticMessageControllerService,
+  StaticMessageCreationModel,
+  StaticMessageModel
+} from '@dungeon-hub/api-client';
+import {AutocompleteComponent} from '../shared/components/autocomplete/autocomplete.component';
+
+type StaticMessageWithActive = StaticMessageModel & { active?: boolean };
+type StaticMessageType = StaticMessageCreationModel.StaticMessageTypeEnum;
+type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: boolean };
+
+@Component({
+  selector: 'app-static-message-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, AutocompleteComponent],
+  template: `
+    <div class="container mx-auto px-4 py-8">
+      <div class="mb-8">
+        <a [routerLink]="['/server', serverId]" class="btn btn-secondary mb-4 inline-block">← Back to Server</a>
+        <h2 class="text-3xl font-bold holographic">Static Messages</h2>
+      </div>
+
+      @if (loadError) {
+        <div class="card bg-red-900/20 border-red-500 mb-8">
+          <div class="flex justify-between items-center">
+            <p class="text-red-400">{{ loadError }}</p>
+            <button (click)="loadStaticMessages()" class="btn btn-secondary">Retry</button>
+          </div>
+        </div>
+      }
+
+      <div class="card">
+        <div class="flex justify-between items-center mb-6">
+          <h3 class="text-2xl font-semibold">Static Messages</h3>
+          <button (click)="showCreateModal = true" class="btn btn-primary">＋ New Static Message</button>
+        </div>
+
+        @if (loading) {
+          <div class="text-center py-12">
+            <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+            <p class="mt-4 text-gray-400">Loading...</p>
+          </div>
+        }
+
+        @if (!loading && staticMessages.length > 0) {
+          <div class="space-y-4">
+            @for (message of staticMessages; track message.id) {
+              <a [routerLink]="['/server', serverId, 'static-message', message.id]" class="block p-4 bg-gray-700 rounded-lg hover:bg-gray-600 transition-colors group">
+                <div class="flex justify-between items-center gap-4">
+                  <div class="flex-1">
+                    <div class="flex flex-wrap items-center gap-3">
+                      <span class="text-lg font-semibold group-hover:text-blue-400 transition-colors">{{ message.staticMessageType }}</span>
+                      <span class="text-sm text-gray-400">#{{ message.id }}</span>
+                      <span class="text-xs px-2 py-1 rounded" [class.bg-green-900]="message.active !== false" [class.text-green-300]="message.active !== false" [class.bg-red-900]="message.active === false" [class.text-red-300]="message.active === false">
+                        {{ message.active === false ? 'Inactive' : 'Active' }}
+                      </span>
+                    </div>
+                    <p class="text-sm text-gray-400 mt-1">Channel: {{ getChannelName(message.channelId) }} ({{ message.channelId }})</p>
+                    @if (message.messageId) {
+                      <p class="text-sm text-gray-400">Message: {{ message.messageId }}</p>
+                    }
+                  </div>
+                  <span class="text-gray-400">→</span>
+                </div>
+              </a>
+            }
+          </div>
+        }
+
+        @if (!loading && staticMessages.length === 0 && !loadError) {
+          <p class="text-gray-400 text-center py-8">No static messages created yet.</p>
+        }
+      </div>
+
+      @if (showCreateModal) {
+        <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" (click)="closeCreateModal()">
+          <div class="card max-w-2xl w-full mx-4" (click)="$event.stopPropagation()">
+            <h3 class="text-xl font-semibold mb-4">Create Static Message</h3>
+            <div class="space-y-4">
+              <div>
+                <label class="label">Type *</label>
+                <select [(ngModel)]="newMessage.staticMessageType" class="input">
+                  @for (type of staticMessageTypes; track type) {
+                    <option [value]="type">{{ type }}</option>
+                  }
+                </select>
+              </div>
+              <div>
+                <label class="label">Channel *</label>
+                <app-autocomplete [items]="discordChannels" displayKey="name" valueKey="id" placeholder="Search channels..." [selectedItem]="selectedCreateChannel" (selectedItemChange)="onCreateChannelSelected($event)" nullLabel="Select a channel" groupByKey="category.id" groupDisplayKey="category.name"></app-autocomplete>
+              </div>
+              <div>
+                <label class="label">Message ID</label>
+                <input [(ngModel)]="newMessage.messageId" type="text" class="input" />
+              </div>
+              <div>
+                <label class="label">Object IDs</label>
+                <textarea [(ngModel)]="newMessage.objectIds" rows="3" class="input font-mono text-sm"></textarea>
+                <small class="text-gray-400">One object ID per line.</small>
+              </div>
+              <div>
+                <label class="label">Embed Override</label>
+                <textarea [(ngModel)]="newMessage.embedOverride" rows="6" class="input font-mono text-sm"></textarea>
+              </div>
+              <label class="flex items-center cursor-pointer">
+                <input [(ngModel)]="newMessage.active" type="checkbox" class="mr-2" />
+                <span class="text-gray-300">Active</span>
+              </label>
+            </div>
+            <div class="flex gap-3 mt-6">
+              <button (click)="closeCreateModal()" class="btn btn-secondary flex-1">Cancel</button>
+              <button (click)="createStaticMessage()" class="btn btn-primary flex-1" [disabled]="!newMessage.channelId || isCreating">{{ isCreating ? 'Creating...' : 'Create' }}</button>
+            </div>
+            @if (createError) {
+              <p class="text-red-400 text-sm mt-4">{{ createError }}</p>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  `
+})
+export class StaticMessageListComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private staticMessageService = inject(StaticMessageControllerService);
+  private discordChannelService = inject(DiscordChannelControllerService);
+  private cdr = inject(ChangeDetectorRef);
+
+  serverId!: string;
+  staticMessages: StaticMessageWithActive[] = [];
+  discordChannels: DiscordChannelModel[] = [];
+  loading = true;
+  loadError: string | null = null;
+  showCreateModal = false;
+  isCreating = false;
+  createError: string | null = null;
+  selectedCreateChannel: DiscordChannelModel | null = null;
+  staticMessageTypes: StaticMessageType[] = ['ScoreLeaderboard', 'TotalLeaderboard', 'ReputationLeaderboard', 'TicketPanel', 'PriceMessage'];
+  newMessage = {
+    channelId: '',
+    messageId: '',
+    staticMessageType: 'ScoreLeaderboard' as StaticMessageType,
+    objectIds: '',
+    embedOverride: '',
+    active: true
+  };
+
+  ngOnInit(): void {
+    this.serverId = this.route.snapshot.params['serverId'];
+    this.loadChannels();
+    this.loadStaticMessages();
+  }
+
+  loadStaticMessages(): void {
+    this.loading = true;
+    this.loadError = null;
+    this.staticMessageService.findStaticMessages(this.serverId).subscribe({
+      next: messages => {
+        this.staticMessages = messages || [];
+        this.loading = false;
+        this.cdr.detectChanges();
+      },
+      error: err => {
+        this.loadError = 'Failed to load static messages. Please try again.';
+        console.error('Error loading static messages:', err);
+        this.loading = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  loadChannels(): void {
+    this.discordChannelService.getAllChannels(this.serverId, false).subscribe({
+      next: channels => {
+        this.discordChannels = channels || [];
+        this.cdr.detectChanges();
+      },
+      error: err => console.error('Failed to load Discord channels:', err)
+    });
+  }
+
+  getChannelName(channelId: string): string {
+    return this.discordChannels.find(channel => channel.id === channelId)?.name || 'Unknown channel';
+  }
+
+  onCreateChannelSelected(channel: DiscordChannelModel | null): void {
+    this.selectedCreateChannel = channel;
+    this.newMessage.channelId = channel?.id || '';
+  }
+
+  closeCreateModal(): void {
+    this.showCreateModal = false;
+    this.createError = null;
+  }
+
+  createStaticMessage(): void {
+    if (!this.newMessage.channelId || this.isCreating) return;
+    this.isCreating = true;
+    this.createError = null;
+
+    const creationModel: StaticMessageCreationWithActive = {
+      channelId: this.newMessage.channelId,
+      messageId: this.newMessage.messageId || undefined,
+      staticMessageType: this.newMessage.staticMessageType,
+      objectIds: this.newMessage.objectIds.split('\n').map(id => id.trim()).filter(Boolean),
+      embedOverride: this.newMessage.embedOverride || undefined,
+      active: this.newMessage.active
+    };
+
+    this.staticMessageService.createStaticMessage(this.serverId, creationModel).subscribe({
+      next: () => {
+        this.isCreating = false;
+        this.showCreateModal = false;
+        this.selectedCreateChannel = null;
+        this.newMessage = {channelId: '', messageId: '', staticMessageType: 'ScoreLeaderboard', objectIds: '', embedOverride: '', active: true};
+        this.loadStaticMessages();
+      },
+      error: err => {
+        this.createError = 'Failed to create static message. Please try again.';
+        console.error('Error creating static message:', err);
+        this.isCreating = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+}

--- a/src/app/features/static-message-list.component.ts
+++ b/src/app/features/static-message-list.component.ts
@@ -1,24 +1,36 @@
 import {ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
+import {forkJoin, of} from 'rxjs';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute, RouterLink} from '@angular/router';
 import {
+  CarryTierControllerService,
+  CarryTypeControllerService,
   DiscordChannelControllerService,
   DiscordChannelModel,
   StaticMessageControllerService,
   StaticMessageCreationModel,
-  StaticMessageModel
+  StaticMessageModel,
+  TicketPanelControllerService
 } from '@dungeon-hub/api-client';
 import {AutocompleteComponent} from '../shared/components/autocomplete/autocomplete.component';
+import {MultiSelectAutocompleteComponent} from '../shared/components/multi-select-autocomplete/multi-select-autocomplete.component';
+import {getStaticMessageTypeLabel, STATIC_MESSAGE_TYPES, StaticMessageType} from './static-message/static-message-labels';
+import {
+  StaticMessageObjectOption,
+  supportsObjectIds,
+  toCarryTierOption,
+  toCarryTypeOption,
+  toTicketPanelOption
+} from './static-message/static-message-object-options';
 
 type StaticMessageWithActive = StaticMessageModel & { active?: boolean };
-type StaticMessageType = StaticMessageCreationModel.StaticMessageTypeEnum;
 type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: boolean };
 
 @Component({
   selector: 'app-static-message-list',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, AutocompleteComponent],
+  imports: [CommonModule, FormsModule, RouterLink, AutocompleteComponent, MultiSelectAutocompleteComponent],
   template: `
     <div class="container mx-auto px-4 py-8">
       <div class="mb-8">
@@ -38,7 +50,7 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
       <div class="card">
         <div class="flex justify-between items-center mb-6">
           <h3 class="text-2xl font-semibold">Static Messages</h3>
-          <button (click)="showCreateModal = true" class="btn btn-primary">＋ New Static Message</button>
+          <button (click)="openCreateModal()" class="btn btn-primary">＋ New Static Message</button>
         </div>
 
         @if (loading) {
@@ -55,15 +67,15 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
                 <div class="flex justify-between items-center gap-4">
                   <div class="flex-1">
                     <div class="flex flex-wrap items-center gap-3">
-                      <span class="text-lg font-semibold group-hover:text-blue-400 transition-colors">{{ message.staticMessageType }}</span>
+                      <span class="text-lg font-semibold group-hover:text-blue-400 transition-colors">{{ getTypeLabel(message.staticMessageType) }}</span>
                       <span class="text-sm text-gray-400">#{{ message.id }}</span>
                       <span class="text-xs px-2 py-1 rounded" [class.bg-green-900]="message.active !== false" [class.text-green-300]="message.active !== false" [class.bg-red-900]="message.active === false" [class.text-red-300]="message.active === false">
                         {{ message.active === false ? 'Inactive' : 'Active' }}
                       </span>
                     </div>
-                    <p class="text-sm text-gray-400 mt-1">Channel: {{ getChannelName(message.channelId) }} ({{ message.channelId }})</p>
+                    <p class="text-sm text-gray-400 mt-1">Channel: {{ getChannelName(message.channelId) }}</p>
                     @if (message.messageId) {
-                      <p class="text-sm text-gray-400">Message: {{ message.messageId }}</p>
+                      <p class="text-sm text-gray-400">Message ID: {{ message.messageId }}</p>
                     }
                   </div>
                   <span class="text-gray-400">→</span>
@@ -85,9 +97,9 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
             <div class="space-y-4">
               <div>
                 <label class="label">Type *</label>
-                <select [(ngModel)]="newMessage.staticMessageType" class="input">
+                <select [(ngModel)]="newMessage.staticMessageType" (ngModelChange)="onCreateTypeChange($event)" class="input">
                   @for (type of staticMessageTypes; track type) {
-                    <option [value]="type">{{ type }}</option>
+                    <option [value]="type">{{ getTypeLabel(type) }}</option>
                   }
                 </select>
               </div>
@@ -95,18 +107,18 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
                 <label class="label">Channel *</label>
                 <app-autocomplete [items]="discordChannels" displayKey="name" valueKey="id" placeholder="Search channels..." [selectedItem]="selectedCreateChannel" (selectedItemChange)="onCreateChannelSelected($event)" nullLabel="Select a channel" groupByKey="category.id" groupDisplayKey="category.name"></app-autocomplete>
               </div>
-              <div>
-                <label class="label">Message ID</label>
-                <input [(ngModel)]="newMessage.messageId" type="text" class="input" />
-              </div>
-              <div>
-                <label class="label">Object IDs</label>
-                <textarea [(ngModel)]="newMessage.objectIds" rows="3" class="input font-mono text-sm"></textarea>
-                <small class="text-gray-400">One object ID per line.</small>
-              </div>
+              @if (shouldShowObjectIds(newMessage.staticMessageType)) {
+                <div>
+                  <label class="label">Object IDs</label>
+                  <app-multi-select-autocomplete [items]="objectOptions" [selectedItems]="selectedCreateObjectOptions" (selectedItemsChange)="onCreateObjectOptionsSelected($event)" displayKey="name" valueKey="id" placeholder="Search objects..." nullLabel="No objects selected"></app-multi-select-autocomplete>
+                </div>
+              }
               <div>
                 <label class="label">Embed Override</label>
-                <textarea [(ngModel)]="newMessage.embedOverride" rows="6" class="input font-mono text-sm"></textarea>
+                <textarea [(ngModel)]="newMessage.embedOverride" (ngModelChange)="validateCreateEmbedOverride()" rows="6" class="input font-mono text-sm"></textarea>
+                @if (createEmbedOverrideError) {
+                  <small class="text-red-400">{{ createEmbedOverrideError }}</small>
+                }
               </div>
               <label class="flex items-center cursor-pointer">
                 <input [(ngModel)]="newMessage.active" type="checkbox" class="mr-2" />
@@ -115,7 +127,7 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
             </div>
             <div class="flex gap-3 mt-6">
               <button (click)="closeCreateModal()" class="btn btn-secondary flex-1">Cancel</button>
-              <button (click)="createStaticMessage()" class="btn btn-primary flex-1" [disabled]="!newMessage.channelId || isCreating">{{ isCreating ? 'Creating...' : 'Create' }}</button>
+              <button (click)="createStaticMessage()" class="btn btn-primary flex-1" [disabled]="!newMessage.channelId || isCreating || !!createEmbedOverrideError">{{ isCreating ? 'Creating...' : 'Create' }}</button>
             </div>
             @if (createError) {
               <p class="text-red-400 text-sm mt-4">{{ createError }}</p>
@@ -130,23 +142,28 @@ export class StaticMessageListComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private staticMessageService = inject(StaticMessageControllerService);
   private discordChannelService = inject(DiscordChannelControllerService);
+  private ticketPanelService = inject(TicketPanelControllerService);
+  private carryTypeService = inject(CarryTypeControllerService);
+  private carryTierService = inject(CarryTierControllerService);
   private cdr = inject(ChangeDetectorRef);
 
   serverId!: string;
   staticMessages: StaticMessageWithActive[] = [];
   discordChannels: DiscordChannelModel[] = [];
+  objectOptions: StaticMessageObjectOption[] = [];
   loading = true;
   loadError: string | null = null;
   showCreateModal = false;
   isCreating = false;
   createError: string | null = null;
+  createEmbedOverrideError: string | null = null;
   selectedCreateChannel: DiscordChannelModel | null = null;
-  staticMessageTypes: StaticMessageType[] = ['ScoreLeaderboard', 'TotalLeaderboard', 'ReputationLeaderboard', 'TicketPanel', 'PriceMessage'];
+  selectedCreateObjectOptions: StaticMessageObjectOption[] = [];
+  staticMessageTypes = STATIC_MESSAGE_TYPES;
   newMessage = {
     channelId: '',
-    messageId: '',
     staticMessageType: 'ScoreLeaderboard' as StaticMessageType,
-    objectIds: '',
+    objectIds: [] as string[],
     embedOverride: '',
     active: true
   };
@@ -155,6 +172,10 @@ export class StaticMessageListComponent implements OnInit {
     this.serverId = this.route.snapshot.params['serverId'];
     this.loadChannels();
     this.loadStaticMessages();
+  }
+
+  getTypeLabel(type: StaticMessageType): string {
+    return getStaticMessageTypeLabel(type);
   }
 
   loadStaticMessages(): void {
@@ -189,27 +210,81 @@ export class StaticMessageListComponent implements OnInit {
     return this.discordChannels.find(channel => channel.id === channelId)?.name || 'Unknown channel';
   }
 
+  openCreateModal(): void {
+    this.showCreateModal = true;
+    this.loadObjectOptions(this.newMessage.staticMessageType);
+  }
+
+  onCreateTypeChange(type: StaticMessageType): void {
+    this.selectedCreateObjectOptions = [];
+    this.newMessage.objectIds = [];
+    this.loadObjectOptions(type);
+  }
+
+  shouldShowObjectIds(type: StaticMessageType): boolean {
+    return supportsObjectIds(type);
+  }
+
+  loadObjectOptions(type: StaticMessageType): void {
+    this.objectOptions = [];
+    if (type === 'TicketPanel') {
+      this.ticketPanelService.getAllTicketPanels(this.serverId).subscribe({next: panels => this.objectOptions = (panels || []).map(toTicketPanelOption)});
+    } else if (type === 'ScoreLeaderboard') {
+      this.carryTypeService.getAllCarryTypes(this.serverId).subscribe({next: carryTypes => this.objectOptions = (carryTypes || []).map(toCarryTypeOption)});
+    } else if (type === 'PriceMessage') {
+      this.carryTypeService.getAllCarryTypes(this.serverId).subscribe({
+        next: carryTypes => {
+          const tierRequests = (carryTypes || []).map(carryType => this.carryTierService.getAllCarryTiers(this.serverId, carryType.id));
+          (tierRequests.length ? forkJoin(tierRequests) : of([])).subscribe({
+            next: carryTierGroups => this.objectOptions = carryTierGroups.flat().map(toCarryTierOption)
+          });
+        }
+      });
+    }
+  }
+
   onCreateChannelSelected(channel: DiscordChannelModel | null): void {
     this.selectedCreateChannel = channel;
     this.newMessage.channelId = channel?.id || '';
   }
 
+  onCreateObjectOptionsSelected(options: StaticMessageObjectOption[]): void {
+    this.selectedCreateObjectOptions = options;
+    this.newMessage.objectIds = options.map(option => option.id);
+  }
+
   closeCreateModal(): void {
     this.showCreateModal = false;
     this.createError = null;
+    this.createEmbedOverrideError = null;
+  }
+
+  validateCreateEmbedOverride(): void {
+    this.createEmbedOverrideError = this.getJsonValidationError(this.newMessage.embedOverride);
+  }
+
+  private getJsonValidationError(value: string): string | null {
+    if (!value.trim()) return null;
+    try {
+      JSON.parse(value);
+      return null;
+    } catch {
+      return 'Invalid JSON format';
+    }
   }
 
   createStaticMessage(): void {
-    if (!this.newMessage.channelId || this.isCreating) return;
+    this.validateCreateEmbedOverride();
+    if (!this.newMessage.channelId || this.isCreating || this.createEmbedOverrideError) return;
     this.isCreating = true;
     this.createError = null;
 
+    const embedOverride = this.newMessage.embedOverride.trim();
     const creationModel: StaticMessageCreationWithActive = {
       channelId: this.newMessage.channelId,
-      messageId: this.newMessage.messageId || undefined,
       staticMessageType: this.newMessage.staticMessageType,
-      objectIds: this.newMessage.objectIds.split('\n').map(id => id.trim()).filter(Boolean),
-      embedOverride: this.newMessage.embedOverride || undefined,
+      objectIds: supportsObjectIds(this.newMessage.staticMessageType) ? this.newMessage.objectIds : [],
+      embedOverride: embedOverride || undefined,
       active: this.newMessage.active
     };
 
@@ -218,7 +293,8 @@ export class StaticMessageListComponent implements OnInit {
         this.isCreating = false;
         this.showCreateModal = false;
         this.selectedCreateChannel = null;
-        this.newMessage = {channelId: '', messageId: '', staticMessageType: 'ScoreLeaderboard', objectIds: '', embedOverride: '', active: true};
+        this.selectedCreateObjectOptions = [];
+        this.newMessage = {channelId: '', staticMessageType: 'ScoreLeaderboard', objectIds: [], embedOverride: '', active: true};
         this.loadStaticMessages();
       },
       error: err => {

--- a/src/app/features/static-message-list.component.ts
+++ b/src/app/features/static-message-list.component.ts
@@ -63,11 +63,11 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
         @if (!loading && staticMessages.length > 0) {
           <div class="space-y-4">
             @for (message of staticMessages; track message.id) {
-              <a [routerLink]="['/server', serverId, 'static-message', message.id]" class="block p-4 bg-gray-700 rounded-lg hover:bg-gray-600 transition-colors group">
-                <div class="flex justify-between items-center gap-4">
+              <div class="p-4 bg-gray-700 rounded-lg transition-colors group">
+                <div class="flex justify-between items-start gap-4">
                   <div class="flex-1">
                     <div class="flex flex-wrap items-center gap-3">
-                      <span class="text-lg font-semibold group-hover:text-blue-400 transition-colors">{{ getTypeLabel(message.staticMessageType) }}</span>
+                      <span class="text-lg font-semibold">{{ getTypeLabel(message.staticMessageType) }}</span>
                       <span class="text-sm text-gray-400">#{{ message.id }}</span>
                       <span class="text-xs px-2 py-1 rounded" [class.bg-green-900]="message.active !== false" [class.text-green-300]="message.active !== false" [class.bg-red-900]="message.active === false" [class.text-red-300]="message.active === false">
                         {{ message.active === false ? 'Inactive' : 'Active' }}
@@ -78,9 +78,14 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
                       <p class="text-sm text-gray-400">Message ID: {{ message.messageId }}</p>
                     }
                   </div>
-                  <span class="text-gray-400">→</span>
+                  <div class="flex flex-col sm:flex-row gap-2">
+                    @if (message.messageId) {
+                      <a [href]="getDiscordMessageUrl(message)" target="_blank" rel="noopener noreferrer" class="btn btn-secondary whitespace-nowrap">Jump to Message</a>
+                    }
+                    <a [routerLink]="['/server', serverId, 'static-message', message.id]" class="btn btn-primary whitespace-nowrap">Edit</a>
+                  </div>
                 </div>
-              </a>
+              </div>
             }
           </div>
         }
@@ -208,6 +213,10 @@ export class StaticMessageListComponent implements OnInit {
 
   getChannelName(channelId: string): string {
     return this.discordChannels.find(channel => channel.id === channelId)?.name || 'Unknown channel';
+  }
+
+  getDiscordMessageUrl(message: StaticMessageModel): string {
+    return `https://discord.com/channels/${this.serverId}/${message.channelId}/${message.messageId}`;
   }
 
   openCreateModal(): void {

--- a/src/app/features/static-message-list.component.ts
+++ b/src/app/features/static-message-list.component.ts
@@ -18,6 +18,7 @@ import {MultiSelectAutocompleteComponent} from '../shared/components/multi-selec
 import {getStaticMessageTypeLabel, STATIC_MESSAGE_TYPES, StaticMessageType} from './static-message/static-message-labels';
 import {
   StaticMessageObjectOption,
+  getObjectOptionTypeLabel,
   supportsObjectIds,
   toCarryTierOption,
   toCarryTypeOption,
@@ -76,6 +77,9 @@ type StaticMessageCreationWithActive = StaticMessageCreationModel & { active?: b
                     <p class="text-sm text-gray-400 mt-1">Channel: {{ getChannelName(message.channelId) }}</p>
                     @if (message.messageId) {
                       <p class="text-sm text-gray-400">Message ID: {{ message.messageId }}</p>
+                    }
+                    @if (getObjectNames(message).length > 0) {
+                      <p class="text-sm text-gray-400">{{ getObjectOptionLabel(message.staticMessageType) }}: {{ getObjectNames(message).join(', ') }}</p>
                     }
                   </div>
                   <div class="flex flex-col sm:flex-row gap-2">
@@ -156,6 +160,9 @@ export class StaticMessageListComponent implements OnInit {
   staticMessages: StaticMessageWithActive[] = [];
   discordChannels: DiscordChannelModel[] = [];
   objectOptions: StaticMessageObjectOption[] = [];
+  private ticketPanelNameById = new Map<string, string>();
+  private carryTypeNameById = new Map<string, string>();
+  private carryTierNameById = new Map<string, string>();
   loading = true;
   loadError: string | null = null;
   showCreateModal = false;
@@ -176,6 +183,7 @@ export class StaticMessageListComponent implements OnInit {
   ngOnInit(): void {
     this.serverId = this.route.snapshot.params['serverId'];
     this.loadChannels();
+    this.loadObjectNameMaps();
     this.loadStaticMessages();
   }
 
@@ -213,6 +221,48 @@ export class StaticMessageListComponent implements OnInit {
 
   getChannelName(channelId: string): string {
     return this.discordChannels.find(channel => channel.id === channelId)?.name || 'Unknown channel';
+  }
+
+  getObjectOptionLabel(type: StaticMessageType): string {
+    return getObjectOptionTypeLabel(type) || 'Object';
+  }
+
+  getObjectNames(message: StaticMessageModel): string[] {
+    if (!supportsObjectIds(message.staticMessageType)) return [];
+
+    const nameMap = message.staticMessageType === 'TicketPanel'
+      ? this.ticketPanelNameById
+      : message.staticMessageType === 'ScoreLeaderboard'
+        ? this.carryTypeNameById
+        : this.carryTierNameById;
+
+    return (message.objectIds || []).map(id => nameMap.get(id) || id);
+  }
+
+  loadObjectNameMaps(): void {
+    this.ticketPanelService.getAllTicketPanels(this.serverId).subscribe({
+      next: panels => {
+        this.ticketPanelNameById = new Map((panels || []).map(panel => [panel.id, toTicketPanelOption(panel).name]));
+        this.cdr.detectChanges();
+      }
+    });
+
+    this.carryTypeService.getAllCarryTypes(this.serverId).subscribe({
+      next: carryTypes => {
+        const carryTypeOptions = (carryTypes || []).map(toCarryTypeOption);
+        this.carryTypeNameById = new Map(carryTypeOptions.map(option => [option.id, option.name]));
+        this.cdr.detectChanges();
+
+        const tierRequests = (carryTypes || []).map(carryType => this.carryTierService.getAllCarryTiers(this.serverId, carryType.id));
+        (tierRequests.length ? forkJoin(tierRequests) : of([])).subscribe({
+          next: carryTierGroups => {
+            const carryTierOptions = carryTierGroups.flat().map(toCarryTierOption);
+            this.carryTierNameById = new Map(carryTierOptions.map(option => [option.id, option.name]));
+            this.cdr.detectChanges();
+          }
+        });
+      }
+    });
   }
 
   getDiscordMessageUrl(message: StaticMessageModel): string {

--- a/src/app/features/static-message/static-message-labels.ts
+++ b/src/app/features/static-message/static-message-labels.ts
@@ -1,0 +1,17 @@
+import {StaticMessageCreationModel} from '@dungeon-hub/api-client';
+
+export type StaticMessageType = StaticMessageCreationModel.StaticMessageTypeEnum;
+
+export const STATIC_MESSAGE_TYPE_LABELS = {
+  ScoreLeaderboard: 'Score Leaderboard',
+  TotalLeaderboard: 'Total Leaderboard',
+  ReputationLeaderboard: 'Reputation Leaderboard',
+  TicketPanel: 'Ticket Panel',
+  PriceMessage: 'Price Message'
+} satisfies Record<StaticMessageType, string>;
+
+export const STATIC_MESSAGE_TYPES = Object.keys(STATIC_MESSAGE_TYPE_LABELS) as StaticMessageType[];
+
+export function getStaticMessageTypeLabel(type: StaticMessageType): string {
+  return STATIC_MESSAGE_TYPE_LABELS[type];
+}

--- a/src/app/features/static-message/static-message-object-options.ts
+++ b/src/app/features/static-message/static-message-object-options.ts
@@ -15,6 +15,19 @@ export function supportsObjectIds(type: StaticMessageType): type is ObjectOption
   return type in STATIC_MESSAGE_OBJECT_OPTION_TYPES;
 }
 
+export function getObjectOptionTypeLabel(type: StaticMessageType): string | null {
+  if (!supportsObjectIds(type)) return null;
+
+  switch (STATIC_MESSAGE_OBJECT_OPTION_TYPES[type]) {
+    case 'TicketPanel':
+      return 'Ticket Panel';
+    case 'CarryType':
+      return 'Carry Type';
+    case 'CarryTier':
+      return 'Carry Tier';
+  }
+}
+
 export function toTicketPanelOption(panel: TicketPanelModel): StaticMessageObjectOption {
   return {id: panel.id, name: panel.displayName || panel.name || panel.id};
 }

--- a/src/app/features/static-message/static-message-object-options.ts
+++ b/src/app/features/static-message/static-message-object-options.ts
@@ -1,0 +1,30 @@
+import {CarryTierModel, CarryTypeModel, StaticMessageCreationModel, TicketPanelModel} from '@dungeon-hub/api-client';
+
+export type StaticMessageType = StaticMessageCreationModel.StaticMessageTypeEnum;
+export type StaticMessageObjectOption = { id: string; name: string };
+
+type ObjectOptionType = Extract<StaticMessageType, 'TicketPanel' | 'ScoreLeaderboard' | 'PriceMessage'>;
+
+export const STATIC_MESSAGE_OBJECT_OPTION_TYPES = {
+  TicketPanel: 'TicketPanel',
+  ScoreLeaderboard: 'CarryType',
+  PriceMessage: 'CarryTier'
+} satisfies Record<ObjectOptionType, 'TicketPanel' | 'CarryType' | 'CarryTier'>;
+
+export function supportsObjectIds(type: StaticMessageType): type is ObjectOptionType {
+  return type in STATIC_MESSAGE_OBJECT_OPTION_TYPES;
+}
+
+export function toTicketPanelOption(panel: TicketPanelModel): StaticMessageObjectOption {
+  return {id: panel.id, name: panel.displayName || panel.name || panel.id};
+}
+
+export function toCarryTypeOption(carryType: CarryTypeModel): StaticMessageObjectOption {
+  return {id: carryType.id, name: carryType.displayName || carryType.identifier || carryType.id};
+}
+
+export function toCarryTierOption(carryTier: CarryTierModel): StaticMessageObjectOption {
+  const carryTypeName = carryTier.carryType?.displayName || carryTier.carryType?.identifier;
+  const carryTierName = carryTier.displayName || carryTier.identifier || carryTier.id;
+  return {id: carryTier.id, name: carryTypeName ? `${carryTypeName} - ${carryTierName}` : carryTierName};
+}

--- a/src/app/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.ts
+++ b/src/app/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.ts
@@ -1,0 +1,148 @@
+import {CommonModule} from '@angular/common';
+import {ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, Input, OnChanges, OnInit, Output, SimpleChanges, inject} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'app-multi-select-autocomplete',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="relative">
+      <button type="button" (click)="toggleDropdown()" class="input flex items-center justify-between w-full text-left min-h-11">
+        <span class="flex-1 truncate">{{ getDisplayValue() }}</span>
+        <svg class="w-4 h-4 transition-transform text-gray-400" [class.rotate-180]="isOpen" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+      </button>
+
+      @if (selectedItems.length > 0) {
+        <div class="flex flex-wrap gap-2 mt-2">
+          @for (item of selectedItems; track getNestedProperty(item, valueKey)) {
+            <button type="button" (click)="removeItem(item)" class="px-2 py-1 rounded bg-blue-900/50 text-blue-200 text-sm hover:bg-blue-800/60">
+              {{ getNestedProperty(item, displayKey) }} ×
+            </button>
+          }
+        </div>
+      }
+
+      @if (isOpen) {
+        <div class="absolute z-50 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg overflow-hidden">
+          <div class="p-2 border-b border-gray-700">
+            <input #searchInput type="text" [(ngModel)]="searchQuery" (input)="filterItems()" [placeholder]="placeholder" class="input w-full" />
+          </div>
+
+          <div class="max-h-60 overflow-y-auto">
+            @for (item of filteredItems; track getNestedProperty(item, valueKey)) {
+              <div (click)="toggleItem(item)" class="px-4 py-2 cursor-pointer hover:bg-gray-700 transition-colors flex items-center justify-between" [class.bg-gray-700]="isItemSelected(item)">
+                <span class="text-gray-300">{{ getNestedProperty(item, displayKey) }}</span>
+                @if (isItemSelected(item)) {
+                  <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                  </svg>
+                }
+              </div>
+            }
+
+            @if (filteredItems.length === 0) {
+              <div class="px-4 py-2 text-gray-500 text-center">No results found</div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  `
+})
+export class MultiSelectAutocompleteComponent implements OnInit, OnChanges {
+  private elementRef = inject(ElementRef);
+  private cdr = inject(ChangeDetectorRef);
+
+  @Input() items: any[] = [];
+  @Input() selectedItems: any[] = [];
+  @Input() displayKey = 'name';
+  @Input() valueKey = 'id';
+  @Input() placeholder = 'Search...';
+  @Input() nullLabel = 'None selected';
+  @Output() selectedItemsChange = new EventEmitter<any[]>();
+
+  isOpen = false;
+  searchQuery = '';
+  filteredItems: any[] = [];
+
+  ngOnInit(): void {
+    this.filterItems();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['items']) {
+      this.filterItems();
+    }
+  }
+
+  toggleDropdown(): void {
+    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.searchQuery = '';
+      this.filterItems();
+      setTimeout(() => this.elementRef.nativeElement.querySelector('input[type="text"]')?.focus(), 0);
+    }
+  }
+
+  toggleItem(item: any): void {
+    if (this.isItemSelected(item)) {
+      this.removeItem(item);
+      return;
+    }
+
+    this.selectedItems = [...this.selectedItems, item];
+    this.selectedItemsChange.emit(this.selectedItems);
+    this.cdr.detectChanges();
+  }
+
+  removeItem(item: any): void {
+    const value = this.getNestedProperty(item, this.valueKey);
+    this.selectedItems = this.selectedItems.filter(selected => this.getNestedProperty(selected, this.valueKey) !== value);
+    this.selectedItemsChange.emit(this.selectedItems);
+    this.cdr.detectChanges();
+  }
+
+  isItemSelected(item: any): boolean {
+    const value = this.getNestedProperty(item, this.valueKey);
+    return this.selectedItems.some(selected => this.getNestedProperty(selected, this.valueKey) === value);
+  }
+
+  getDisplayValue(): string {
+    if (this.selectedItems.length === 0) {
+      return this.nullLabel;
+    }
+
+    if (this.selectedItems.length === 1) {
+      return this.getNestedProperty(this.selectedItems[0], this.displayKey) || this.nullLabel;
+    }
+
+    return `${this.selectedItems.length} selected`;
+  }
+
+  filterItems(): void {
+    if (!this.searchQuery) {
+      this.filteredItems = this.items;
+      return;
+    }
+
+    const query = this.searchQuery.toLowerCase();
+    this.filteredItems = this.items.filter(item => {
+      const displayValue = this.getNestedProperty(item, this.displayKey);
+      return typeof displayValue === 'string' && displayValue.toLowerCase().includes(query);
+    });
+  }
+
+  getNestedProperty(obj: any, path: string): any {
+    return path.split('.').reduce((current, key) => current?.[key], obj);
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: Event): void {
+    if (!this.elementRef.nativeElement.contains(event.target)) {
+      this.isOpen = false;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a UI to manage static messages so admins can change the target channel, override embeds, and toggle an `active` flag for existing static messages.
- The API client exposes the channel as `channelId` and `embedOverride`, and the dashboard needs to expose these fields along with `messageId` and `objectIds` for create/edit flows.
- The `active` property is not present in the newest typed client but must be supported by the UI, so the UI should assume it exists for now.

### Description
- Register two authenticated routes: `server/:serverId/static-messages` and `server/:serverId/static-message/:staticMessageId` in `src/app/app.routes.ts` to load the new list and edit components.
- Add a dashboard entry in `src/app/features/server/server-detail.component.ts` linking to the new static message management page.
- Add `StaticMessageListComponent` in `src/app/features/static-message-list.component.ts` with listing, create modal, channel selection via `app-autocomplete`, `staticMessageType` selection, `embedOverride`, newline-separated `objectIds`, `messageId`, and assumed `active` support.
- Add `StaticMessageEditComponent` in `src/app/features/static-message-edit.component.ts` with a reactive form to edit `channelId` (and channel selection via autocomplete), `messageId`, `embedOverride`, `resetEmbedOverride`, newline-separated `objectIds`, and the assumed `active` field; local types `StaticMessageWithActive` / `StaticMessageUpdateWithActive` are used to include `active`.

### Testing
- Ran `npm run build` and the application bundle generated successfully (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42006c64048322aeebc3018100a687)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated **Static Messages** navigation under `server/:serverId`, including lazy-loaded list and edit screens.
  - Introduced a **Static Messages** page with cards, loading/error handling, and a **Create Static Message** modal (channel, optional object IDs, optional embed override).
  - Added a reusable **multi-select autocomplete** component for object selection.
  - Added a **Static Messages** section to the server details view.

- **Bug Fixes**
  - Improved OAuth redirect and login/callback handling to make authentication flow more reliable, including safer return-url navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->